### PR TITLE
installkernel: Don't force hostonly

### DIFF
--- a/installkernel
+++ b/installkernel
@@ -148,7 +148,7 @@ esac
 # Generate initial ramdisk
 #
 if [ -x /usr/bin/dracut -a -d /lib/modules/$KERNEL_VERSION ]; then
-    /usr/bin/dracut --hostonly --force $CHECK_SUPPORTED \
+    /usr/bin/dracut --force $CHECK_SUPPORTED \
         $INSTALL_PATH/initrd-$KERNEL_VERSION $KERNEL_VERSION
 else
     echo "You may need to create an initial ramdisk now."


### PR DESCRIPTION
Using --hostonly on the cmdline overrides the configurations in
/etc/dracut.conf.d/ which makes it impossible to create nohostonly
initrds with installkernel. The default behaviour of dracut is hostonly
so removing it from the script will keep the same behaviour but allow
for other dracut configs.

Signed-off-by: Patrik Jakobsson <pjakobsson@suse.de>